### PR TITLE
Fix version check bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ def check_system():
         return False
     
     # Check Python version
-    if sys.version_info < (3, 8):
+    # Compare only major and minor numbers to avoid TypeError
+    if sys.version_info[:2] < (3, 8):
         print("❌ Python 3.8+ required")
         return False
     


### PR DESCRIPTION
## Summary
- fix Python version comparison to avoid TypeError

## Testing
- `python3 -m py_compile setup.py autodeepseek.py gui.py test_autodeepseek.py`
- `python3 test_autodeepseek.py` *(fails: download blocked, huge model)*

------
https://chatgpt.com/codex/tasks/task_e_6850d4f47c8c8330a1b8b47e638a4c36