### PR TITLE
Fix setup script to use bash for shell commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,14 @@ def run_command(command, description=""):
     print(f"Running: {command}")
     
     try:
-        result = subprocess.run(command, shell=True, check=True, 
-                              capture_output=True, text=True)
+        result = subprocess.run(
+            command,
+            shell=True,
+            check=True,
+            capture_output=True,
+            text=True,
+            executable="/bin/bash",
+        )
         print("✅ Success")
         return True
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- ensure `setup.py` uses bash for shell commands

## Testing
- `python3 -m py_compile setup.py`
- `python3 -m py_compile autodeepseek.py gui.py test_autodeepseek.py`
- `python3 test_autodeepseek.py` *(fails to download model)*

------
https://chatgpt.com/codex/tasks/task_e_68515dcd99bc8330b2163b719800e3e3